### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "pimple/pimple": "^3.0",
         "psr/simple-cache": "^1.0",
         "symfony/cache": "^3.3 || ^4.3 || ^5.0",
-        "symfony/event-dispatcher": "^4.3 || ^5.0",
+        "symfony/event-dispatcher": "^4.3",
         "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0 || ^5.0",
         "symfony/psr-http-message-bridge": "^0.3 || ^1.0 || ^2.0"
     },


### PR DESCRIPTION
调用小程序直播列表接口时
symfony/event-dispatcher v5.1 在php7.2会报错，它只能运行在7.3以上的环境。